### PR TITLE
Skip tab navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@ionic-native/core": "^5.0.0",
     "@ionic-native/splash-screen": "^5.0.0",
     "@ionic-native/status-bar": "^5.0.0",
-    "@ionic/angular": "^4.1.0",
+    "@ionic/angular": "^4.5.0",
     "core-js": "^2.5.4",
     "rxjs": "~6.5.1",
     "tslib": "^1.9.0",

--- a/src/app/app-tabs.ts
+++ b/src/app/app-tabs.ts
@@ -1,0 +1,84 @@
+import { Component, ContentChild, EventEmitter, HostListener, Output, ViewChild } from '@angular/core';
+import {IonRouterOutlet, IonTabBar, NavController} from '@ionic/angular';
+import {StackEvent} from '@ionic/angular/dist/directives/navigation/stack-utils';
+
+
+@Component({
+    selector: 'app-tabs-component',
+    template: `
+    <ng-content select="[slot=top]"></ng-content>
+    <div class="tabs-inner">
+      <ion-router-outlet #outlet tabs="true" (stackEvents)="onPageSelected($event)"></ion-router-outlet>
+    </div>
+    <ng-content></ng-content>`,
+    styles: [`
+    :host {
+      display: flex;
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+
+      flex-direction: column;
+
+      width: 100%;
+      height: 100%;
+
+      contain: layout size style;
+      z-index: $z-index-page-container;
+    }
+    .tabs-inner {
+      position: relative;
+
+      flex: 1;
+
+      contain: layout size style;
+    }`
+    ]
+})
+export class AppTabsComponent {
+
+    @ViewChild('outlet', { read: IonRouterOutlet }) outlet: IonRouterOutlet;
+    @ContentChild(IonTabBar) tabBar: IonTabBar | undefined;
+
+    @Output() ionTabsWillChange = new EventEmitter<{tab: string}>();
+    @Output() ionTabsDidChange = new EventEmitter<{tab: string}>();
+
+    constructor(
+        private navCtrl: NavController,
+    ) {}
+
+    /**
+     * @internal
+     */
+    onPageSelected(detail: StackEvent) {
+        const stackId = detail.enteringView.stackId;
+        if (detail.tabSwitch && stackId !== undefined) {
+            if (this.tabBar) {
+                this.tabBar.selectedTab = stackId;
+            }
+            this.ionTabsWillChange.emit({ tab: stackId });
+            this.ionTabsDidChange.emit({ tab: stackId });
+        }
+    }
+
+    @HostListener('ionTabButtonClick', ['$event.detail.tab'])
+    select(tab: string) {
+        const alreadySelected = this.outlet.getActiveStackId() === tab;
+        const href = `${this.outlet.tabsPrefix}/${tab}`;
+        const url = alreadySelected
+            ? href
+            : this.outlet.getLastUrl(tab) || href;
+
+        return this.navCtrl.navigateRoot(url, {
+            animated: true,
+            animationDirection: 'back',
+            skipLocationChange: true
+        });
+    }
+
+    getSelected(): string | undefined {
+        return this.outlet.getActiveStackId();
+    }
+}

--- a/src/app/tabs/tabs.module.ts
+++ b/src/app/tabs/tabs.module.ts
@@ -6,6 +6,7 @@ import { FormsModule } from '@angular/forms';
 import { TabsPageRoutingModule } from './tabs.router.module';
 
 import { TabsPage } from './tabs.page';
+import {AppTabsComponent} from '../app-tabs';
 
 @NgModule({
   imports: [
@@ -14,6 +15,6 @@ import { TabsPage } from './tabs.page';
     FormsModule,
     TabsPageRoutingModule
   ],
-  declarations: [TabsPage]
+  declarations: [TabsPage, AppTabsComponent]
 })
 export class TabsPageModule {}

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -1,4 +1,4 @@
-<ion-tabs>
+<app-tabs-component>
 
   <ion-tab-bar slot="bottom">
     <ion-tab-button tab="tab1">
@@ -17,4 +17,4 @@
     </ion-tab-button>
   </ion-tab-bar>
 
-</ion-tabs>
+</app-tabs-component>


### PR DESCRIPTION
Here a simple workaround for your issue. In Angular you can 
navigate to a page without pushing a new state into history with `skipLocationChange: true`.

```ts
        return this.navCtrl.navigateRoot(url, {
            animated: true,
            animationDirection: 'back',
            skipLocationChange: true
        });
```
The problem is that `ion-tabs` does not provide a way to set this, so I created a copy of      
https://github.com/ionic-team/ionic/blob/master/angular/src/directives/navigation/ion-tabs.ts      
and added `skipLocationChange: true` 


